### PR TITLE
added the summary metadata object directly to the MetaDataStore class

### DIFF
--- a/src/main/java/org/mm2python/DataStructures/Builders/MDSBuilder.java
+++ b/src/main/java/org/mm2python/DataStructures/Builders/MDSBuilder.java
@@ -24,7 +24,8 @@ public class MDSBuilder extends MDSBuilderBase {
 
                 image,
                 dataprovider,
-                coord);
+                coord,
+                summaryMetadata);
     }
 
     /**

--- a/src/main/java/org/mm2python/DataStructures/Builders/MDSBuilderBase.java
+++ b/src/main/java/org/mm2python/DataStructures/Builders/MDSBuilderBase.java
@@ -3,6 +3,7 @@ package org.mm2python.DataStructures.Builders;
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
 import org.micromanager.data.Datastore;
+import org.micromanager.data.SummaryMetadata;
 import org.mm2python.DataStructures.MetaDataStore;
 
 /**
@@ -28,6 +29,8 @@ abstract public class MDSBuilderBase {
     DataProvider dataprovider;
 
     Coords coord;
+
+    SummaryMetadata summaryMetadata;
 
     public MDSBuilderBase time(int t) {
         this.time = t;
@@ -102,6 +105,11 @@ abstract public class MDSBuilderBase {
 
     public MDSBuilderBase coord(Coords coord_) {
         this.coord = coord_;
+        return this;
+    }
+
+    public MDSBuilderBase summaryMetadata(SummaryMetadata sumdat_) {
+        this.summaryMetadata = sumdat_;
         return this;
     }
 

--- a/src/main/java/org/mm2python/DataStructures/MetaDataStore.java
+++ b/src/main/java/org/mm2python/DataStructures/MetaDataStore.java
@@ -2,6 +2,7 @@ package org.mm2python.DataStructures;
 
 import org.micromanager.data.Coords;
 import org.micromanager.data.DataProvider;
+import org.micromanager.data.SummaryMetadata;
 
 import java.util.Objects;
 
@@ -30,6 +31,9 @@ public class MetaDataStore {
 
     private Coords coord;
 
+    private SummaryMetadata summaryMetadata;
+
+
     // package private constructor
     public MetaDataStore(Integer z_, Integer pos_, Integer time_, Integer channel_,
                          Integer x_dim_, Integer y_dim_, Integer bitDepth_,
@@ -37,7 +41,8 @@ public class MetaDataStore {
                          String filepath_, Integer buffer_position_,
                          Object image_,
                          DataProvider dataProvider_,
-                         Coords coord_)
+                         Coords coord_,
+                         SummaryMetadata summaryMetadata_)
     {
         // positivity check
         if
@@ -72,6 +77,9 @@ public class MetaDataStore {
 
         if(dataProvider_ != null) {this.dataprovider = dataProvider_;}
         if(coord_ != null) {this.coord = coord_;}
+
+        // assign metadata
+        summaryMetadata = summaryMetadata_;
     }
 
     public Integer getZ() { return this.z;}
@@ -111,6 +119,8 @@ public class MetaDataStore {
     public DataProvider getDataProvider() {return this.dataprovider;}
 
     public Coords getCoord() {return this.coord;}
+
+    public SummaryMetadata getSummaryMetadata() {return this.summaryMetadata;}
 
 
     /**

--- a/src/main/java/org/mm2python/mmEventHandler/datastoreEventsThread.java
+++ b/src/main/java/org/mm2python/mmEventHandler/datastoreEventsThread.java
@@ -169,6 +169,7 @@ public class datastoreEventsThread implements Runnable {
 //                    .image(temp_img.getRawPixels())
                     .dataprovider(data)
                     .coord(coord)
+                    .summaryMetadata(summary)
 
                     .buildMDS();
         } catch(IllegalAccessException ilex){


### PR DESCRIPTION
Micromanager provides its own metadata object (Summary Metadata).  The MDS class already pulls critical information from this.  This PR provides the entirety of the SummaryMetadata object from the MDS class.